### PR TITLE
adding php-simplexml module to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositorie
     php7-xmlreader \
     php7-xml \
     php7-xmlwriter \
+    php7-simplexml \
     php7-posix \
     php7-openssl \
     php7-ldap \


### PR DESCRIPTION
Your current dockerfile unfortunately doesn't work because nextcloud complains about simplexml module is missing. This change should fix it.